### PR TITLE
[Fix] 修复可能的None字段

### DIFF
--- a/vnpy_tushare/tushare_datafeed.py
+++ b/vnpy_tushare/tushare_datafeed.py
@@ -246,8 +246,8 @@ class TushareDatafeed(BaseDatafeed):
                     low_price=round_to(row["low"], 0.000001),
                     close_price=round_to(row["close"], 0.000001),
                     volume=row["vol"],
-                    turnover=row.get("amount", 0),
-                    open_interest=row.get("oi", 0),
+                    turnover=row.get("amount", 0) if row.get("amount", 0) else 0,
+                    open_interest=row.get("oi", 0) if row.get("oi", 0) else 0,
                     gateway_name="TS"
                 )
 


### PR DESCRIPTION
row.get的default value仅在字段不存在时生效。
当tushare返回的值中存在oi字段，但值为None时，依旧会取None值，从而导致后续的存入数据库失败